### PR TITLE
Update mozilla.com->mozilla.org URLs for Bug 679556

### DIFF
--- a/copyright.html
+++ b/copyright.html
@@ -1,15 +1,15 @@
 <div id="copyright">
   <p id="footer-links">
     {% block footer_links %}
-    <a href="http://mozilla.com/privacy-policy.html">{{ _('Privacy Policy') }}</a> &nbsp;|&nbsp;
-    <a href="http://mozilla.com/about/legal.html">{{ _('Legal Notices') }}</a> &nbsp;|&nbsp;
-    <a href="http://mozilla.com/legal/fraud-report/index.html">{{ _('Report Trademark Abuse') }}</a>
+    <a href="http://www.mozilla.org/privacy-policy.html">{{ _('Privacy Policy') }}</a> &nbsp;|&nbsp;
+    <a href="http://www.mozilla.org/about/legal.html">{{ _('Legal Notices') }}</a> &nbsp;|&nbsp;
+    <a href="http://www.mozilla.org/legal/fraud-report/index.html">{{ _('Report Trademark Abuse') }}</a>
     {% block extra_footer_links %}{% endblock %}
     {% endblock %}
   </p>
   <p>
     {% trans %}
-      Except where otherwise <a href="http://mozilla.com/about/legal.html#site">noted</a>,
+      Except where otherwise <a href="http://www.mozilla.org/about/legal.html#site">noted</a>,
       content on this site is licensed under the <br />
       <a href="http://creativecommons.org/licenses/by-sa/3.0/">
         Creative Commons Attribution Share-Alike License v3.0

--- a/footer.html
+++ b/footer.html
@@ -3,7 +3,7 @@
     {% endblock %}
 </div>
 
-<div id="footer-logo"><a href="http://mozilla.com/" title="{{ _('Back to home page') }}">{{ _('Firefox') }}</a></div>
+<div id="footer-logo"><a href="http://www.mozilla.org/" title="{{ _('Back to home page') }}">{{ _('Firefox') }}</a></div>
 
 <div id="footer-menu" role="navigation">
   {% block menu_links %}

--- a/header.html
+++ b/header.html
@@ -4,7 +4,7 @@
     <a href="#lang_form">{{ _('switch language') }}</a>
   </div>
 
-  <h1><a href="http://www.mozilla.com/?ref=logo" title="{{ _('Back to Mozilla.com') }}">{{ _('Firefox') }}</a></h1>
+  <h1><a href="http://www.mozilla.org/?ref=logo" title="{{ _('Back to Mozilla.com') }}">{{ _('Firefox') }}</a></h1>
   <a class="mozilla" href="http://www.mozilla.org/?ref=logo">{{ _('visit <span>mozilla.org</span>')|safe }}</a>
 
   <div id="nav-main" role="navigation">

--- a/menu_links.html
+++ b/menu_links.html
@@ -1,27 +1,27 @@
 <ul>
   {% block feature_links %}
-  <li class="first"><a href="http://www.mozilla.com/firefox/features/">{{ _('Features') }}</a>
+  <li class="first"><a href="http://www.mozilla.org/firefox/features/">{{ _('Features') }}</a>
     <ul>
-      <li class="first"><a href="http://www.mozilla.com/firefox/features/">{{ _('Features') }}</a></li>
-      <li><a href="http://www.mozilla.com/firefox/security/">{{ _('Security') }}</a></li>
-      <li><a href="http://www.mozilla.com/firefox/performance/">{{ _('Performance') }}</a></li>
-      <li><a href="http://www.mozilla.com/firefox/customize/">{{ _('Customization') }}</a></li>
-      <li><a href="http://www.mozilla.com/firefox/video/">{{ _('Videos') }}</a></li>
-      <li class="last"><a href="http://www.mozilla.com/firefox/central/">{{ _('Tour') }}</a></li>
+      <li class="first"><a href="http://www.mozilla.org/firefox/features/">{{ _('Features') }}</a></li>
+      <li><a href="http://www.mozilla.org/firefox/security/">{{ _('Security') }}</a></li>
+      <li><a href="http://www.mozilla.org/firefox/performance/">{{ _('Performance') }}</a></li>
+      <li><a href="http://www.mozilla.org/firefox/customize/">{{ _('Customization') }}</a></li>
+      <li><a href="http://www.mozilla.org/firefox/video/">{{ _('Videos') }}</a></li>
+      <li class="last"><a href="http://www.mozilla.org/firefox/central/">{{ _('Tour') }}</a></li>
     </ul>
   </li>
   {% endblock %}
   {% block mobile_links %}
-  <li><a href="http://www.mozilla.com/mobile/">{{ _('Mobile') }}</a>
+  <li><a href="http://www.mozilla.org/mobile/">{{ _('Mobile') }}</a>
     <ul>
-      <li class="first"><a href="http://www.mozilla.com/mobile/">{{ _('Mobile Overview') }}</a></li>
-      <li><a href="http://www.mozilla.com/mobile/download/">{{ _('Download') }}</a></li>
-      <li><a href="http://www.mozilla.com/mobile/features/">{{ _('Features') }}</a></li>
+      <li class="first"><a href="http://www.mozilla.org/mobile/">{{ _('Mobile Overview') }}</a></li>
+      <li><a href="http://www.mozilla.org/mobile/download/">{{ _('Download') }}</a></li>
+      <li><a href="http://www.mozilla.org/mobile/features/">{{ _('Features') }}</a></li>
       <li><a href="https://addons.mozilla.org/mobile/?browse=featured">{{ _('Customize') }}</a></li>
-      <li><a href="http://www.mozilla.com/mobile/sync/">{{ _('Sync') }}</a></li>
+      <li><a href="http://www.mozilla.org/mobile/sync/">{{ _('Sync') }}</a></li>
       <li><a href="https://developer.mozilla.org/mobile">{{ _('Develop') }}</a></li>
-      <li><a href="http://www.mozilla.com/mobile/getinvolved/">{{ _('Get Involved') }}</a></li>
-      <li><a href="http://www.mozilla.com/mobile/faq/">{{ _('FAQ') }}</a></li>
+      <li><a href="http://www.mozilla.org/mobile/getinvolved/">{{ _('Get Involved') }}</a></li>
+      <li><a href="http://www.mozilla.org/mobile/faq/">{{ _('FAQ') }}</a></li>
       <li class="last"><a href="https://blog.mozilla.com/mobile/">{{ _('Blog') }}</a></li>
     </ul>
   </li>
@@ -52,15 +52,15 @@
     </li>
   {% endblock %}
   {% block about_links %}
-  <li class="last"><a href="http://www.mozilla.com/about/">{{ _('About') }}</a>
+  <li class="last"><a href="http://www.mozilla.org/about/">{{ _('About') }}</a>
     <ul>
-      <li class="first"><a href="http://www.mozilla.com/about/">{{ _('About Firefox') }}</a></li>
-      <li><a href="http://www.mozilla.com/about/participate/">{{ _('Participate') }}</a></li>
-      <li><a href="http://www.mozilla.com/press/">{{ _('Communications') }}</a></li>
-      <li><a href="http://www.mozilla.com/about/careers.html">{{ _('Careers') }}</a></li>
-      <li><a href="http://www.mozilla.com/about/partnerships.html">{{ _('Partnerships') }}</a></li>
-      <li><a href="http://www.mozilla.com/about/legal.html">{{ _('Legal') }}</a></li>
-      <li><a href="http://www.mozilla.com/about/contact.html">{{ _('Contact Us') }}</a></li>
+      <li class="first"><a href="http://www.mozilla.org/about/">{{ _('About Firefox') }}</a></li>
+      <li><a href="http://www.mozilla.org/about/participate/">{{ _('Participate') }}</a></li>
+      <li><a href="http://www.mozilla.org/press/">{{ _('Communications') }}</a></li>
+      <li><a href="http://www.mozilla.org/about/careers.html">{{ _('Careers') }}</a></li>
+      <li><a href="http://www.mozilla.org/about/partnerships.html">{{ _('Partnerships') }}</a></li>
+      <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal') }}</a></li>
+      <li><a href="http://www.mozilla.org/about/contact.html">{{ _('Contact Us') }}</a></li>
       <li class="last"><a href="http://blog.mozilla.com/">{{ _('Blog') }}</a></li>
     </ul>
   </li>


### PR DESCRIPTION
Updated the mozilla.com URLs with mozilla.org. Also added the leading "www." to a few instances, since there is a redirect anyhow.

This relates to Bug 679556
https://bugzilla.mozilla.org/show_bug.cgi?id=679556
