### PR TITLE
updated careers link to work with new site url

### DIFF
--- a/menu_links.html
+++ b/menu_links.html
@@ -62,7 +62,7 @@
         <li><a href="http://www.mozilla.org/about/participate/">{{ _('Participate') }}</a></li>
         <li><a href="http://www.mozilla.org/press/">{{ _('Press Center') }}</a></li>
         <li><a href="http://www.mozilla.org/en-US/firefox/brand/">{{ _('Brand Toolkit') }}</a></li>
-        <li><a href="http://www.mozilla.org/about/careers.html">{{ _('Careers') }}</a></li>
+        <li><a href="http://www.mozilla.org/careers">{{ _('Careers') }}</a></li>
         <li><a href="http://www.mozilla.org/about/partnerships.html">{{ _('Partnerships') }}</a></li>
         <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal') }}</a></li>
         <li><a href="http://www.mozilla.org/about/contact.html">{{ _('Contact Us') }}</a></li>


### PR DESCRIPTION
The new careers site is being rewritten and it is likely that the existing url will not exist after launch. So I've updated the link to point to a url that currently works and will work post-launch.
