### PR TITLE
Bug 884087 - remove "more ways to connect" from footer and fix links

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -9,14 +9,11 @@
         <li id="footer-facebook"><a href="http://Facebook.com/Firefox">
           {{ _('Facebook') }}
         </a></li>
-        <li id="footer-connect"><a href="http://www.mozilla.com/firefox/connect/">
-          {{ _('More Ways to Connect') }}
-        </a></li>
       </ul>
 
       <p id="sub-footer-newsletter">
         <span class="intro">{{ _('Want us to keep in touch?') }}</span>
-        <a href="http://www.mozilla.com/newsletter/">{{ _('Get Monthly News <span>»</span>') }}</a>
+        <a href="http://www.mozilla.org/newsletter/">{{ _('Get Monthly News <span>»</span>') }}</a>
       </p>
     {% endblock %}
   </div>
@@ -30,37 +27,35 @@
     </div>
 
     <h3 id="footer-logo">
-      <a href="http://www.mozilla.com/firefox/" title="{{ _('Back to home page') }}">{{ _('Firefox') }}</a>
+      <a href="http://www.mozilla.org/firefox/" title="{{ _('Back to home page') }}">{{ _('Firefox') }}</a>
     </h3>
 
     {# start footer menu #}
     <div id="footer-menu" role="navigation">
       <ul>
         <li>
-          <a href="http://www.mozilla.com/firefox/features/">{{ _('Desktop') }}</a>
+          <a href="http://www.mozilla.org/firefox/features/">{{ _('Desktop') }}</a>
           <ul>
-            <li><a href="http://www.mozilla.com/firefox/features/">{{ _('Features') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/security/">{{ _('Security') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/performance/">{{ _('Performance') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/customize/">{{ _('Customization') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/technology/">{{ _('Technology') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/video/">{{ _('Videos') }}</a></li>
-            <li><a href="http://www.mozilla.com/firefox/central/">{{ _('Tour') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/features/">{{ _('Features') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/security/">{{ _('Security') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/performance/">{{ _('Performance') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/customize/">{{ _('Customization') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/technology/">{{ _('Technology') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/video/">{{ _('Videos') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/central/">{{ _('Tour') }}</a></li>
           </ul>
         </li>
 
         <li>
-          <a href="http://www.mozilla.com/mobile/">{{ _('Mobile') }}</a>
+          <a href="http://www.mozilla.org/mobile/">{{ _('Mobile') }}</a>
           <ul>
-            <li><a href="http://www.mozilla.com/mobile/">{{ _('Mobile Overview') }}</a></li>
-            <li><a href="http://www.mozilla.com/mobile/download/">{{ _('Download') }}</a></li>
-            <li><a href="http://www.mozilla.com/mobile/features/">{{ _('Features') }}</a></li>
-            <li><a href="https://addons.mozilla.org/mobile/?browse=featured">{{ _('Customize') }}</a></li>
-            <li><a href="http://www.mozilla.com/mobile/sync/">{{ _('Sync') }}</a></li>
+            <li><a href="http://www.mozilla.org/mobile/">{{ _('Mobile Overview') }}</a></li>
+            <li><a href="http://www.mozilla.org/mobile/features/">{{ _('Features') }}</a></li>
+            <li><a href="https://addons.mozilla.org/android/">{{ _('Customize') }}</a></li>
+            <li><a href="http://www.mozilla.org/mobile/sync/">{{ _('Sync') }}</a></li>
             <li><a href="https://developer.mozilla.org/mobile">{{ _('Develop') }}</a></li>
-            <li><a href="http://www.mozilla.com/mobile/getinvolved/">{{ _('Get Involved') }}</a></li>
-            <li><a href="http://www.mozilla.com/mobile/faq/">{{ _('FAQ') }}</a></li>
-            <li><a href="https://blog.mozilla.com/mobile/">{{ _('Blog') }}</a></li>
+            <li><a href="http://www.mozilla.org/contribute/">{{ _('Get Involved') }}</a></li>
+            <li><a href="http://www.mozilla.org/firefox/mobile/faq/">{{ _('FAQ') }}</a></li>
           </ul>
         </li>
 
@@ -71,7 +66,6 @@
             <li><a href="https://addons.mozilla.org/firefox/featured/">{{ _('Featured Add-ons') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/extensions/">{{ _('Extensions') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/themes/">{{ _('Themes') }}</a></li>
-            <li><a href="http://www.getpersonas.com/">{{ _('Personas') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/search-tools/">{{ _('Search Tools') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/language-tools/">{{ _('Language Support') }}</a></li>
             <li><a href="https://addons.mozilla.org/firefox/collections/">{{ _('Collections') }}</a></li>
@@ -81,26 +75,26 @@
         </li>
 
         <li>
-          <a href="http://support.mozilla.com/">{{ _('Support') }}</a>
+          <a href="http://support.mozilla.org/">{{ _('Support') }}</a>
           <ul>
-            <li><a href="http://support.mozilla.com/kb/">{{ _('Firefox Support') }}</a></li>
-            <li><a href="http://support.mozilla.com/mobile">{{ _('Mobile Support') }}</a></li>
-            <li><a href="http://support.mozillamessaging.com/kb/">{{ _('Thunderbird Support') }}</a></li>
+            <li><a href="http://support.mozilla.org/kb/">{{ _('Firefox Support') }}</a></li>
+            <li><a href="http://support.mozilla.org/mobile">{{ _('Mobile Support') }}</a></li>
+            <li><a href="http://support.mozillamessaging.com">{{ _('Thunderbird Support') }}</a></li>
           </ul>
         </li>
 
         <li>
-          <a href="http://www.mozilla.com/about/">{{ _('About') }}</a>
+          <a href="http://www.mozilla.org/about/">{{ _('About') }}</a>
           <ul>
-            <li><a href="http://www.mozilla.com/about/">{{ _('About Firefox') }}</a></li>
-            <li><a href="http://www.mozilla.org/join">{{ _('Join Mozilla') }}</a></li>
-            <li><a href="http://www.mozilla.com/about/participate/">{{ _('Participate') }}</a></li>
-            <li><a href="http://www.mozilla.com/press/">{{ _('Press Center') }}</a></li>
-            <li><a href="http://www.mozilla.com/about/careers.html">{{ _('Careers') }}</a></li>
-            <li><a href="http://www.mozilla.com/about/partnerships.html">{{ _('Partnerships') }}</a></li>
-            <li><a href="http://www.mozilla.com/about/legal.html">{{ _('Legal') }}</a></li>
-            <li><a href="http://www.mozilla.com/about/contact.html">{{ _('Contact Us') }}</a></li>
-            <li><a href="http://blog.mozilla.com/">{{ _('Blog') }}</a></li>
+            <li><a href="http://www.mozilla.org/about/">{{ _('About Firefox') }}</a></li>
+            <li><a href="http://sendto.mozilla.org">{{ _('Join Mozilla') }}</a></li>
+            <li><a href="http://http://www.mozilla.org/contribute/">{{ _('Participate') }}</a></li>
+            <li><a href="http://blog.mozilla.org/press/">{{ _('Press Center') }}</a></li>
+            <li><a href="http://careers.mozilla.org">{{ _('Careers') }}</a></li>
+            <li><a href="http://www.mozilla.org/about/partnerships/">{{ _('Partnerships') }}</a></li>
+            <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal') }}</a></li>
+            <li><a href="http://www.mozilla.org/about/contact.html">{{ _('Contact Us') }}</a></li>
+            <li><a href="http://blog.mozilla.org/">{{ _('Blog') }}</a></li>
           </ul>
         </li>
 
@@ -110,14 +104,14 @@
 
     <div id="copyright">
       <ul id="footer-links">
-        <li><a href="http://www.mozilla.com/privacy-policy.html">{{ _('Privacy Policy') }}</a></li>
-        <li><a href="http://www.mozilla.com/about/legal.html">{{ _('Legal Notices') }}</a></li>
-        <li class="last"><a href="http://www.mozilla.com/legal/fraud-report/index.html">
+        <li><a href="http://www.mozilla.org/en-US/privacy/">{{ _('Privacy Policy') }}</a></li>
+        <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal Notices') }}</a></li>
+        <li class="last"><a href="http://www.mozilla.org/legal/fraud-report/index.html">
           {{ _('Report Trademark Abuse') }}
         </a></li>
       </ul>
       <p>
-        {% trans legal_url='http://www.mozilla.com/about/legal.html#site',
+        {% trans legal_url='http://www.mozilla.org/about/legal.html#site',
                  license_url='http://creativecommons.org/licenses/by-sa/3.0/' %}
           Except where otherwise <a href="{{ legal_url }}">noted</a>,
           content on this site is licensed under the <br/>


### PR DESCRIPTION
Removed the <li> for "more ways to connect" and then fixed a ton of mozilla.com links in the footer. I also removed a link to the mobile blog as it hasn't been changed since 2011.
